### PR TITLE
bug fix for textures and calllists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Release version
 m4_define([package_version_major],[1])
 m4_define([package_version_minor],[0])
-m4_define([package_version_micro],[0])
+m4_define([package_version_micro],[1])
  m4_define([package_repository],[https://github.com/astronaos/BWM801])
 m4_define([package_auth_email],[bwmulligan@astronaos.com])
 

--- a/src/bwm801_calllist.cpp
+++ b/src/bwm801_calllist.cpp
@@ -37,6 +37,6 @@ void calllist::Initializer(void)
 }
 void calllist::Destructor(void)
 { 
-	Delete();
+	//Delete(); // don't delete! Because the calllist is a class the list may be copied through multiple instances. We don't want to delete the list when a copy is destroyed
 }
 

--- a/src/bwm801_texture.cpp
+++ b/src/bwm801_texture.cpp
@@ -166,7 +166,7 @@ void texture::Initializer(void)
 
 void texture::Destructor(void)
 {
-	Delete();
+	//Delete(); // don't delete! Because the texture is a class the texture may be copied through multiple instances. We don't want to delete the texture when a copy is destroyed
 }
 
 void texture::Load_Image(const std::string & i_sFile_Path, int i_iMipmap_Level)


### PR DESCRIPTION
textures and calllists were being deleted when the class destructor was called. This can cause problems when copies of the calllist or texture are made (e.g. if contained in a map, vector, queue, etc.). The user is now responsible for deleting all calllists and textures.